### PR TITLE
issue-179 - curator does not configure crontab logger correctly

### DIFF
--- a/curator/run_cron.py
+++ b/curator/run_cron.py
@@ -9,7 +9,7 @@ import logging
 from crontab import CronTab
 from datetime import datetime
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
 # log at INFO by default
 logger.setLevel(logging.INFO)
 lh = logging.StreamHandler()


### PR DESCRIPTION
Get the root logger by calling `logging.getLogger()` with no arguments.
The root logger config setting is inherited by all other loggers.

@sosiouxme @ewolinetz PTAL
