### PR TITLE
use java-headless package - faster build, smaller image size

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -26,7 +26,7 @@ ADD elasticsearch.repo /etc/yum.repos.d/elasticsearch.repo
 # install the RPMs in a separate step so it can be cached
 RUN rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
     yum install -y --setopt=tsflags=nodocs \
-                java-1.8.0-openjdk \
+                java-1.8.0-openjdk-headless \
                 elasticsearch && \
     yum clean all
 # initial boring elasticsearch.yml is just to enable plugin installation.


### PR DESCRIPTION
We don't need the full Java with all of the GUI components for ES - using headless gives us faster build, smaller image
@sosiouxme @ewolinetz PTAL
