### PR TITLE
use curator v 3.x - we cannot use 4.x yet

### DIFF
--- a/curator/install.sh
+++ b/curator/install.sh
@@ -6,7 +6,7 @@ rpm -q epel-release || yum -y install https://dl.fedoraproject.org/pub/epel/epel
 yum install -y --setopt=tsflags=nodocs \
   python-pip \
   PyYAML
-pip install elasticsearch-curator python-crontab
+pip install 'elasticsearch-curator<4.0' python-crontab
 yum clean all
 
 mkdir -p ${HOME}


### PR DESCRIPTION
looks like curator 4.0 was officially released to pypi - and it doesn't work with our code - drop back to 3.x for now.
@sosiouxme @ewolinetz PTAL
