### PR TITLE
curator date/times are with respect to the curator pod timezone

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:centos7
 
 MAINTAINER OpenShift Development <dev@lists.openshift.redhat.com>
 
-# by default, run the curator cron job at midnight every night, and delete
+# by default, run the curator cron job at midnight UTC every night, and delete
 # indices older than 30 days old
 ENV HOME=/opt/app-root/src \
     ES_HOST=localhost \
@@ -13,7 +13,8 @@ ENV HOME=/opt/app-root/src \
     CURATOR_CONF_LOCATION=/etc/curator/settings/config.yaml \
     CURATOR_DEFAULT_DAYS=30 \
     CURATOR_RUN_HOUR=0 \
-    CURATOR_RUN_MINUTE=0
+    CURATOR_RUN_MINUTE=0 \
+    CURATOR_RUN_TIMEZONE=UTC
 
 LABEL io.k8s.description="Curator elasticsearch container for elasticsearch deletion/archival" \
   io.k8s.display-name="Curator 3.5.1" \

--- a/curator/README.md
+++ b/curator/README.md
@@ -24,18 +24,7 @@ projects that are not specified
 curator jobs
 ** runminute: NUMBER - minute of the hour at which to run the curator jobs
 ** timezone: STRING - String in tzselect(8) or timedatectl(1) format - the
-   default timezone is the timezone of the curator pod, which by default should
-   be the timezone of the node
-
-The curator pod should use the same timezone as its node.  If you are not sure
-what is the curator pod timezone, or what timezone string you should use, you
-can check::
-
-    # oc get pods -l component=curator # get the pod name
-    # oc exec $pod -- date +%Z%z
-    UTC+0000
-    # tzselect - this will give you an interactive way to choose a timezone string
-    # timedatectl list-timezones - this will give you a list of all timezone strings
+   default timezone is `UTC`
 
 For example, using::
 

--- a/curator/run_cron.py
+++ b/curator/run_cron.py
@@ -32,7 +32,7 @@ decoded = {}
 with open(filename, 'r') as stream:
     decoded = yaml.load(stream) or {}
 
-tzstr = decoded.get('.defaults', {}).get('timezone', os.getenv('CURATOR_RUN_TIMEZONE', None))
+tzstr = decoded.get('.defaults', {}).get('timezone', os.getenv('CURATOR_RUN_TIMEZONE', 'UTC'))
 tz = None
 if tzstr:
     try:


### PR DESCRIPTION
https://github.com/openshift/origin-integration-common/issues/13
Just use UTC for the default timezone so we don't have to fool with
mounting `/etc/localtime` in the curator pod.
